### PR TITLE
Prepend package when available to cpp methods

### DIFF
--- a/src/org/shoebox/macros/MacroMirrors.hx
+++ b/src/org/shoebox/macros/MacroMirrors.hx
@@ -321,8 +321,11 @@ class MacroMirrors{
 								trace( $v{ sPackage }+"::"+$v{ sName }+'($iArgs)' );
 							#end
 
-							//
-								$i{ sVar_name } = cpp.Lib.load( $v{ sPackage } , $v{ sName } , $v{ iArgs });
+                            var primitive = $v{ sName };
+                            if ($v{ sPackage } != null && $v{ sPackage } != "") {
+                                primitive = $v{ sPackage } + "_" + $v{ sName };
+                            }
+							$i{ sVar_name } = cpp.Lib.load( $v{ sPackage } , primitive , $v{ iArgs });
 
 						}
 


### PR DESCRIPTION
I ran into an issue with HypRate that the methods would not be found on iOS because the namespace/package name was not prepended to the primitive name.

I have added logic to add the package and an underscore to the primitive name if the package is not null or empty string.

See hyperfiction/HypRate#2 for the code that will require these changes.
