### PR TITLE
Refactoring & CPP improvements

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -5,7 +5,7 @@
 	"tags": ["hyperfiction", "macro","shoebox","openfl"],
 	"description": "Essential macros for native extensions",
 	"classPath":"src/",
-	"version": "1.0.4",
-	"releasenote": "The library is now usable as a haxelib (missing 'classPath' node)",
+	"version": "1.1.0",
+	"releasenote": "Refactoring | CPP default primtive prefix | CPP default library",
 	"contributors": ["shoebox"]  
 }

--- a/src/org/shoebox/macros/MacroMirrors.hx
+++ b/src/org/shoebox/macros/MacroMirrors.hx
@@ -196,7 +196,7 @@ class MacroMirrors
 			{
 				#if verbose_mirrors
 				trace("Lib not loaded, loading it");
-				trace($v{packageName} + " :: " + $v{mirrorName} 
+				trace($v{packageName} + " :: " + $v{variableName} 
 					+ ' :: signature '+$v{signature});
 				#end
 


### PR DESCRIPTION
The IOS & CPP meta are now optionals.

The primitve name et library can now be setup globally by the following class metas:

@CPP_DEFAULT_LIBRARY("hyp-system")
@CPP_PRIMITIVE_PREFIX("hypsystem_device")
