### PR TITLE
Jni : Add default class name

### DIFF
--- a/src/mirror/JniFieldTool.hx
+++ b/src/mirror/JniFieldTool.hx
@@ -14,6 +14,7 @@ using tools.MetadataTools;
  class JniFieldTool
  {
  	public static inline var TagJni = 'JNI';
+ 	public static inline var TagDefaultClassName = 'JNI_DEFAULT_CLASS_NAME';
  	public static inline var TagDefaultLibrary = 'JNI_DEFAULT_PACKAGE';
 
  	public static function isJni(field:Field):Bool
@@ -49,15 +50,42 @@ using tools.MetadataTools;
 			}
 			else
 			{
-				result = Context.getLocalModule();
-				hasFileName = true;
+				if (metas.has(TagDefaultClassName) 
+					&& metas.get(TagDefaultClassName).params.length > 0)
+				{
+					trace("TagDefaultClassName");
+					hasFileName = false;
+				}
+				else
+				{
+					result = Context.getLocalModule();
+					hasFileName = true;
+				}
 			}
  		}
 
  		var splitted = result.split('.');
-
  		if (!hasFileName)
- 			splitted.push(Context.getLocalClass().get().name);
+ 		{
+ 			if (metas.has(TagDefaultClassName))
+ 			{
+ 				if (metas.get(TagDefaultClassName).params.length == 0)
+	 			{
+	 				#if (haxe_ver >= 3.1)
+					Context.fatalError("Default package is defined " 
+						+ '($TagDefaultClassName) without argument', field.pos);
+					#end
+	 			}	
+	 			else
+	 			{
+	 				splitted.push(metas.get(TagDefaultClassName).params[0].getString());
+	 			}
+ 			}
+ 			else
+ 			{
+ 				splitted.push(Context.getLocalClass().get().name);
+ 			}
+ 		}
 
  		result = splitted.join("/");
  		

--- a/src/mirror/JniFieldTool.hx
+++ b/src/mirror/JniFieldTool.hx
@@ -53,7 +53,6 @@ using tools.MetadataTools;
 				if (metas.has(TagDefaultClassName) 
 					&& metas.get(TagDefaultClassName).params.length > 0)
 				{
-					trace("TagDefaultClassName");
 					hasFileName = false;
 				}
 				else

--- a/src/mirror/Mirror.hx
+++ b/src/mirror/Mirror.hx
@@ -32,25 +32,26 @@ class Mirror
 		var isAndroid = #if munit true #else Context.defined("android") #end;
 		var isOpenFl = Context.defined("openfl") || Context.defined("nme");
 		var isEnabled = #if (openfl || munit) true #else false #end;
-			
 		var fieldDisabled:Bool;
 		var func:Function;
-		if (isEnabled)
-		{
-			var localClass = Context.getLocalClass().get();
-			var result:Field;
-			for (field in fields.copy())
-			{	
-				switch (field.kind)
-				{
-					case FFun(f):
-					default : continue;
-				}
+		
+		var localClass = Context.getLocalClass().get();
+		var result:Field;
+		for (field in fields.copy())
+		{	
+			
+			switch (field.kind)
+			{
+				case FFun(f):
+				default : continue;
+			}
 
-				func = field.getFunction();
-				if (func.ret == null)
-					func.ret = VOID;
+			func = field.getFunction();
+			if (func.ret == null)
+				func.ret = VOID;
 
+			if (isEnabled)
+			{
 				fieldDisabled = field.meta.has(MirrorDisabledMeta);
 				if (!fieldDisabled)
 				{
@@ -69,20 +70,20 @@ class Mirror
 					fields.push(result);
 					result = null;
 				}
-				
-				if (func.expr == null)
+			}
+			
+			if (func.expr == null)
+			{
+				func.expr = switch (func.ret.toString())
 				{
-					func.expr = switch (func.ret.toString())
+					case "Bool" : macro return false;
+					case "Float" : macro return -1.0;
+					case "Void" : macro 
 					{
-						case "Bool" : macro return false;
-						case "Float" : macro return -1.0;
-						case "Void" : macro 
-						{
-							//Nothing
-						};
-						case "Int" : macro return 0;
-						default : macro return null;
-					}
+						//Nothing
+					};
+					case "Int" : macro return 0;
+					default : macro return null;
 				}
 			}
 		}

--- a/test/src/JniTest.hx
+++ b/test/src/JniTest.hx
@@ -32,40 +32,38 @@ class JniTest
 
 	@Test public function testAbstractSignature1()
 	{
-		Assert.areEqual(meta1.method1.jni_signature[0], 
-			"(Ljava/lang/String;ZI)Ljava/lang/String;");
+		Assert.areEqual("(Ljava/lang/String;ZI)Ljava/lang/String;", 
+			meta1.method1.jni_signature[0]);
 	}
 
 	@Test public function testPrimitive1()
 	{
-		Assert.areEqual(meta1.method1.jni_primitive[0], "method1");
+		Assert.areEqual("method1", meta1.method1.jni_primitive[0]);
 	}
 
 	@Test public function testAbstractSignature2()
 	{
-		Assert.areEqual(meta1.method2.jni_signature[0], "(ZIF)Z");
+		Assert.areEqual("(ZIF)Z", meta1.method2.jni_signature[0]);
 	}
 
 	@Test public function testPrimitive2()
 	{
-		Assert.areEqual(meta1.method2.jni_primitive[0], "primitivename");
+		Assert.areEqual("primitivename", meta1.method2.jni_primitive[0]);
 	}
 
 	@Test public function testAbstractSignature3()
 	{
-		Assert.areEqual(meta1.method3.jni_signature[0], 
-			"(Ljava/lang/String;IF)V");
+		Assert.areEqual("(Ljava/lang/String;IF)V", meta1.method3.jni_signature[0]);
 	}
 
 	@Test public function testPrimitive3()
 	{
-		Assert.areEqual(meta1.method2.jni_primitive[0], "primitivename");
+		Assert.areEqual("primitivename", meta1.method2.jni_primitive[0]);
 	}
 
 	@Test public function testAbstractSignature4()
 	{
-		Assert.areEqual(meta1.method4.jni_signature[0], 
-			"(Ltestpackage/TestClass;ZI)I");
+		Assert.areEqual("(Ltestpackage/TestClass;ZI)I", meta1.method4.jni_signature[0]);
 	}
 
 	@Test public function testPrimitive4()
@@ -82,12 +80,12 @@ class JniTest
 
 	@Test public function testPackageMeta()
 	{
-		Assert.areEqual(meta1.method4.jni_package[0], "package/toto/com/TestJni1");
+		Assert.areEqual("package/toto/com/TestJni1", meta1.method4.jni_package[0]);
 	}
 
 	@Test public function testDefaultPackage()
 	{
-		Assert.areEqual(meta2.methodAlt.jni_package[0], 
-			"org/shoebox/testpackagealt/TestJni2");	
+		Assert.areEqual("org/shoebox/testpackagealt/TestJni2", 
+			meta2.methodAlt.jni_package[0]);	
 	}
 }


### PR DESCRIPTION
- Add a new class meta tag `@JNI_DEFAULT_CLASS_NAME("class name")`  (JNI only)
- The function default body is now working as excepted for non - JNI / IOS / CPP mirrors
- Adjustements in the unit tests
