### PR TITLE
Rewrite `getPackageName()` to reduce the chance of errors

### DIFF
--- a/src/mirror/Jni.hx
+++ b/src/mirror/Jni.hx
@@ -1,5 +1,6 @@
 package mirror;
 
+#if macro
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
@@ -102,3 +103,4 @@ class Jni
 		return 'mirror_jni_$name';
 	}
 }
+#end

--- a/src/mirror/JniFieldTool.hx
+++ b/src/mirror/JniFieldTool.hx
@@ -1,5 +1,6 @@
- package mirror;
+package mirror;
 
+#if macro
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
@@ -19,7 +20,7 @@ using tools.MetadataTools;
 
  	public static function isJni(field:Field):Bool
  	{
- 		return field.meta.has(TagJni);
+		return field.meta.has(TagJni);
  	}
 
  	public static function getPackageName(field:Field):String
@@ -239,3 +240,5 @@ using tools.MetadataTools;
 		return result;
 	}
  }
+
+#end

--- a/src/tools/FieldTool.hx
+++ b/src/tools/FieldTool.hx
@@ -1,5 +1,6 @@
 package tools;
 
+#if macro
 import haxe.macro.Context;
 import haxe.macro.Expr;
 
@@ -25,3 +26,4 @@ class FieldTool
 		return result;
 	}
 }
+#end


### PR DESCRIPTION
Apparently the previous implementation could lead to duplicating the class name (see #19). While I'm not certain what was going on, this revision attempts to minimize the chances that it'll happen again.